### PR TITLE
Use Hashicorp releases service instead of Bintray

### DIFF
--- a/ch02/packer/Vagrantfile
+++ b/ch02/packer/Vagrantfile
@@ -11,7 +11,7 @@ wget -qO- https://get.docker.com/ | sh
 gpasswd -a vagrant docker
 service docker restart
 apt-get -y install wget unzip
-wget https://dl.bintray.com/mitchellh/packer/packer_0.8.5_linux_amd64.zip
+wget https://releases.hashicorp.com/packer/0.8.5/packer_0.8.5_linux_amd64.zip
 unzip /home/vagrant/packer_0.8.5_linux_amd64.zip
 SCRIPT
 

--- a/ch02/vagrantprovider/docker-bootstrap.sh
+++ b/ch02/vagrantprovider/docker-bootstrap.sh
@@ -3,7 +3,7 @@
 sudo apt-get update
 sudo apt-get -y install docker.io
 sudo apt-get -y install wget
-sudo wget https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2_x86_64.deb
+sudo wget https://releases.hashicorp.com/vagrant/1.7.2/vagrant_1.7.2_x86_64.deb
 sudo dpkg -i vagrant_1.7.2_x86_64.deb
 sudo gpasswd -a vagrant docker
 sudo service docker.io restart


### PR DESCRIPTION
Resolves #10 by replacing URIs with current ones using same (old) Packer and Vagrant versions.